### PR TITLE
Fix DataProto save test with tmp_path

### DIFF
--- a/verl/tests/utility/test_tensor_dict_utilities.py
+++ b/verl/tests/utility/test_tensor_dict_utilities.py
@@ -244,21 +244,18 @@ def test_dataproto_fold_unfold():
     assert data3.meta_info == {'info': 'test_info'}
 
 
-def test_torch_save_data_proto():
+def test_torch_save_data_proto(tmp_path):
 
     obs = torch.tensor([[1, 2], [3, 4], [5, 6]])
     labels = ['a', 'b', 'c']
     data = DataProto.from_dict(tensors={'obs': obs}, non_tensors={'labels': labels}, meta_info={'info': 'test_info'})
-    data.save_to_disk('test_data.pt')
-    loaded_data = DataProto.load_from_disk('test_data.pt')
+    file_path = tmp_path / 'test_data.pt'
+    data.save_to_disk(file_path)
+    loaded_data = DataProto.load_from_disk(file_path)
 
     assert torch.all(torch.eq(loaded_data.batch['obs'], data.batch['obs']))
     assert (loaded_data.non_tensor_batch['labels'] == data.non_tensor_batch['labels']).all()
     assert loaded_data.meta_info == data.meta_info
-
-    import os
-    os.remove('test_data.pt')
-
 
 def test_len():
     obs = torch.tensor([[1, 2], [3, 4], [5, 6]])


### PR DESCRIPTION
### **User description**
## Summary
- use pytest's tmp_path fixture in `test_torch_save_data_proto`
- remove manual file cleanup

## Testing
- `pytest verl/tests/utility/test_tensor_dict_utilities.py::test_torch_save_data_proto -q`

------
https://chatgpt.com/codex/tasks/task_e_6885aedd57f483339d32a0f958f9c6d7


___

### **PR Type**
Tests


___

### **Description**
- Replace manual file cleanup with pytest's `tmp_path` fixture

- Remove hardcoded filename and manual `os.remove()` call

- Improve test isolation and cleanup handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Manual file handling"] --> B["pytest tmp_path fixture"]
  B --> C["Automatic cleanup"]
  D["Hardcoded filename"] --> E["Dynamic temp path"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_tensor_dict_utilities.py</strong><dd><code>Refactor test to use pytest tmp_path fixture</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

verl/tests/utility/test_tensor_dict_utilities.py

<ul><li>Add <code>tmp_path</code> parameter to test function signature<br> <li> Replace hardcoded filename with dynamic temp path<br> <li> Remove manual <code>os.remove()</code> cleanup call<br> <li> Remove unnecessary <code>import os</code> statement</ul>


</details>


  </td>
  <td><a href="https://github.com/creator-codie/Absolute-Zero-Reasoner/pull/2/files#diff-04d1cba773cf245b2d782d186f655d53510c9803eb5f246113c4edff1e8c33d1">+4/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

