### PR TITLE
Fix docstring to mention raw_prompt in rl_dataset

### DIFF
--- a/absolute_zero_reasoner/utils/dataset/rl_dataset.py
+++ b/absolute_zero_reasoner/utils/dataset/rl_dataset.py
@@ -139,7 +139,8 @@ class RLHFDataset(Dataset):
 
     def __getitem__(self, item):
         """
-        Note that we also return the raw_input_ids so that it can be combined with other chat template
+        When ``return_raw_chat`` is True, ``raw_prompt`` is also returned so it
+        can be combined with other chat template.
         """
         row_dict = self.dataframe.iloc[item].to_dict()
 


### PR DESCRIPTION
### **User description**
## Summary
- update rl_dataset docstring to clarify `raw_prompt` is returned when `return_raw_chat` is enabled

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6885aedbf1c08333b6721b0d3ada1f99


___

### **PR Type**
Documentation


___

### **Description**
- Update docstring to clarify `raw_prompt` return behavior

- Improve documentation for `return_raw_chat` parameter usage


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rl_dataset.py</strong><dd><code>Update docstring for raw_prompt return behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

absolute_zero_reasoner/utils/dataset/rl_dataset.py

<ul><li>Updated <code>__getitem__</code> method docstring to clarify <code>raw_prompt</code> return<br> <li> Improved documentation for <code>return_raw_chat</code> parameter behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/creator-codie/Absolute-Zero-Reasoner/pull/3/files#diff-ae765040cee8143573911fa5e8d2a36018e7f0d473b1c2ba431da7f8ddbc1f2a">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

