### PR TITLE
Fix parse_inputs_message regex handling

### DIFF
--- a/absolute_zero_reasoner/rewards/code_reward.py
+++ b/absolute_zero_reasoner/rewards/code_reward.py
@@ -419,10 +419,10 @@ def parse_inputs_message(
     flags = re.DOTALL | re.IGNORECASE
 
     # Check required blocks
-    input_matches = re.finditer(input_pattern, input_str, flags)
+    input_matches = list(re.finditer(input_pattern, input_str, flags))
     if not input_matches:
         # Try alternative pattern without explicit input block
-        input_matches = re.finditer(r"# Input:\s*(.*?)(?=\n```|$)", input_str, flags)
+        input_matches = list(re.finditer(r"# Input:\s*(.*?)(?=\n```|$)", input_str, flags))
 
     # Get all inputs and take the last num_inputs
     inputs = [match.group(1).strip() for match in input_matches]


### PR DESCRIPTION
### **User description**
## Summary
- fix parse_inputs_message to evaluate regex results correctly
- convert iterator from `re.finditer` into a list before checking emptiness

## Testing
- `pytest -k parse_inputs_message -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6885aed93f348333b5a66bb3e209318a


___

### **PR Type**
Bug fix


___

### **Description**
- Fix regex iterator evaluation in `parse_inputs_message` function

- Convert `re.finditer` results to list for proper emptiness checking


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["re.finditer() iterator"] --> B["list() conversion"] --> C["emptiness check works correctly"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>code_reward.py</strong><dd><code>Fix regex iterator to list conversion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

absolute_zero_reasoner/rewards/code_reward.py

<ul><li>Convert <code>re.finditer()</code> results to lists for both input pattern matches<br> <li> Enable proper boolean evaluation of regex match results<br> <li> Fix emptiness checking logic for iterator objects</ul>


</details>


  </td>
  <td><a href="https://github.com/creator-codie/Absolute-Zero-Reasoner/pull/4/files#diff-1bae31bdb846d65645530e522b60898fcf7ad03b553b15092d5000f5f5f48bb0">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

